### PR TITLE
Fix ring section layout and remove duplicate content

### DIFF
--- a/src/components/WhatsMoreImportantSection.tsx
+++ b/src/components/WhatsMoreImportantSection.tsx
@@ -40,15 +40,11 @@ export default function WhatsMoreImportantSection() {
             </div>
 
             {/* Content */}
-            <div className="text-center">
-              <h4 className="text-stone-600 font-semibold text-lg mb-6 tracking-wide">
-                Start Designing Your Ring
-              </h4>
-
+            <div className="text-left">
               <p className="text-black text-sm lg:text-base leading-relaxed mb-8 font-medium">
-                Its time to build your dream ring. Start by choosing your favourite 
-                engagement ring design then pair it with your ideal diamond or 
-                gemstone. Finish by selecting your favourite metal colour. These rings 
+                Its time to build your dream ring. Start by choosing your favourite
+                engagement ring design then pair it with your ideal diamond or
+                gemstone. Finish by selecting your favourite metal colour. These rings
                 are made to order within 8 weeks.
               </p>
 
@@ -57,9 +53,9 @@ export default function WhatsMoreImportantSection() {
                 className="inline-flex items-center text-stone-700 font-semibold text-lg hover:text-stone-800 transition-colors duration-300"
               >
                 Start Designing Your Ring
-                <svg 
-                  className="ml-2 w-3 h-4 transform rotate-90" 
-                  fill="currentColor" 
+                <svg
+                  className="ml-2 w-3 h-4"
+                  fill="currentColor"
                   viewBox="0 0 9 13"
                 >
                   <path d="M0.224965 11.6535L0.680433 11.2741L6.41482 6.50947L0.695125 1.72429L0.239461 1.34394L0.692005 0.959639L1.09275 0.61923L1.41431 0.346123L1.73728 0.616962L8.32635 6.12764L8.78689 6.5119L8.32556 6.89522L1.71933 12.3845L1.39581 12.6547L0.675741 12.0387L0.224965 11.6535Z"/>
@@ -93,14 +89,10 @@ export default function WhatsMoreImportantSection() {
             </div>
 
             {/* Content */}
-            <div className="text-center">
-              <h4 className="text-stone-600 font-semibold text-lg mb-6 tracking-wide">
-                Shop Ready to Ship Rings
-              </h4>
-
+            <div className="text-left">
               <p className="text-black text-sm lg:text-base leading-relaxed mb-8 font-medium">
-                Sometimes love can&apos;t wait. These fully finished and heritage hand 
-                crafted rings are in stock and ready to ship. Receive your ring fully 
+                Sometimes love can&apos;t wait. These fully finished and heritage hand
+                crafted rings are in stock and ready to ship. Receive your ring fully
                 resized, under 2 weeks.
               </p>
 
@@ -109,9 +101,9 @@ export default function WhatsMoreImportantSection() {
                 className="inline-flex items-center text-stone-700 font-semibold text-lg hover:text-stone-800 transition-colors duration-300"
               >
                 Shop Ready to Ship Rings
-                <svg 
-                  className="ml-2 w-3 h-4 transform rotate-90" 
-                  fill="currentColor" 
+                <svg
+                  className="ml-2 w-3 h-4"
+                  fill="currentColor"
                   viewBox="0 0 9 13"
                 >
                   <path d="M0.224965 11.6535L0.680433 11.2741L6.41482 6.50947L0.695125 1.72429L0.239461 1.34394L0.692005 0.959639L1.09275 0.61923L1.41431 0.346123L1.73728 0.616962L8.32635 6.12764L8.78689 6.5119L8.32556 6.89522L1.71933 12.3845L1.39581 12.6547L0.675741 12.0387L0.224965 11.6535Z"/>
@@ -145,15 +137,11 @@ export default function WhatsMoreImportantSection() {
             </div>
 
             {/* Content */}
-            <div className="text-center">
-              <h4 className="text-stone-600 font-semibold text-lg mb-6 tracking-wide">
-                Shop Curated Collection
-              </h4>
-
+            <div className="text-left">
               <p className="text-black text-sm lg:text-base leading-relaxed mb-8 font-medium">
-                Prefer not to make a hundred tiny decisions? We&apos;ve combined our 
-                most-loved ring designs with hand-selected, exquisite diamonds, so 
-                you can entrust our team with curating your one-of-a-kind heirloom. 
+                Prefer not to make a hundred tiny decisions? We&apos;ve combined our
+                most-loved ring designs with hand-selected, exquisite diamonds, so
+                you can entrust our team with curating your one-of-a-kind heirloom.
                 Made to order. Crafted by experts. Completed within 8 weeks.
               </p>
 
@@ -162,9 +150,9 @@ export default function WhatsMoreImportantSection() {
                 className="inline-flex items-center text-stone-700 font-semibold text-lg hover:text-stone-800 transition-colors duration-300"
               >
                 Shop Curated Collection
-                <svg 
-                  className="ml-2 w-3 h-4 transform rotate-90" 
-                  fill="currentColor" 
+                <svg
+                  className="ml-2 w-3 h-4"
+                  fill="currentColor"
                   viewBox="0 0 9 13"
                 >
                   <path d="M0.224965 11.6535L0.680433 11.2741L6.41482 6.50947L0.695125 1.72429L0.239461 1.34394L0.692005 0.959639L1.09275 0.61923L1.41431 0.346123L1.73728 0.616962L8.32635 6.12764L8.78689 6.5119L8.32556 6.89522L1.71933 12.3845L1.39581 12.6547L0.675741 12.0387L0.224965 11.6535Z"/>
@@ -174,14 +162,6 @@ export default function WhatsMoreImportantSection() {
           </div>
         </div>
 
-        {/* Additional Information */}
-        <div className="mt-16 lg:mt-20 text-center">
-          <p className="text-stone-600 text-lg font-medium max-w-3xl mx-auto leading-relaxed">
-            Every piece is a testament to British craftsmanship, designed to
-            become a cherished heirloom that tells your unique love story for
-            generations to come.
-          </p>
-        </div>
       </div>
     </section>
   );

--- a/src/components/WhatsMoreImportantSection.tsx
+++ b/src/components/WhatsMoreImportantSection.tsx
@@ -39,15 +39,8 @@ export default function WhatsMoreImportantSection() {
               </div>
             </div>
 
-            {/* Content */}
-            <div className="text-left">
-              <p className="text-black text-sm lg:text-base leading-relaxed mb-8 font-medium">
-                Its time to build your dream ring. Start by choosing your favourite
-                engagement ring design then pair it with your ideal diamond or
-                gemstone. Finish by selecting your favourite metal colour. These rings
-                are made to order within 8 weeks.
-              </p>
-
+            {/* Link */}
+            <div className="text-left mb-6">
               <Link
                 href="/design-ring"
                 className="inline-flex items-center text-stone-700 font-semibold text-lg hover:text-stone-800 transition-colors duration-300"
@@ -61,6 +54,16 @@ export default function WhatsMoreImportantSection() {
                   <path d="M0.224965 11.6535L0.680433 11.2741L6.41482 6.50947L0.695125 1.72429L0.239461 1.34394L0.692005 0.959639L1.09275 0.61923L1.41431 0.346123L1.73728 0.616962L8.32635 6.12764L8.78689 6.5119L8.32556 6.89522L1.71933 12.3845L1.39581 12.6547L0.675741 12.0387L0.224965 11.6535Z"/>
                 </svg>
               </Link>
+            </div>
+
+            {/* Description */}
+            <div className="text-left">
+              <p className="text-black text-sm lg:text-base leading-relaxed font-medium">
+                Its time to build your dream ring. Start by choosing your favourite
+                engagement ring design then pair it with your ideal diamond or
+                gemstone. Finish by selecting your favourite metal colour. These rings
+                are made to order within 8 weeks.
+              </p>
             </div>
           </div>
 
@@ -88,14 +91,8 @@ export default function WhatsMoreImportantSection() {
               </div>
             </div>
 
-            {/* Content */}
-            <div className="text-left">
-              <p className="text-black text-sm lg:text-base leading-relaxed mb-8 font-medium">
-                Sometimes love can&apos;t wait. These fully finished and heritage hand
-                crafted rings are in stock and ready to ship. Receive your ring fully
-                resized, under 2 weeks.
-              </p>
-
+            {/* Link */}
+            <div className="text-left mb-6">
               <Link
                 href="/ready-to-ship"
                 className="inline-flex items-center text-stone-700 font-semibold text-lg hover:text-stone-800 transition-colors duration-300"
@@ -109,6 +106,15 @@ export default function WhatsMoreImportantSection() {
                   <path d="M0.224965 11.6535L0.680433 11.2741L6.41482 6.50947L0.695125 1.72429L0.239461 1.34394L0.692005 0.959639L1.09275 0.61923L1.41431 0.346123L1.73728 0.616962L8.32635 6.12764L8.78689 6.5119L8.32556 6.89522L1.71933 12.3845L1.39581 12.6547L0.675741 12.0387L0.224965 11.6535Z"/>
                 </svg>
               </Link>
+            </div>
+
+            {/* Description */}
+            <div className="text-left">
+              <p className="text-black text-sm lg:text-base leading-relaxed font-medium">
+                Sometimes love can&apos;t wait. These fully finished and heritage hand
+                crafted rings are in stock and ready to ship. Receive your ring fully
+                resized, under 2 weeks.
+              </p>
             </div>
           </div>
 
@@ -136,15 +142,8 @@ export default function WhatsMoreImportantSection() {
               </div>
             </div>
 
-            {/* Content */}
-            <div className="text-left">
-              <p className="text-black text-sm lg:text-base leading-relaxed mb-8 font-medium">
-                Prefer not to make a hundred tiny decisions? We&apos;ve combined our
-                most-loved ring designs with hand-selected, exquisite diamonds, so
-                you can entrust our team with curating your one-of-a-kind heirloom.
-                Made to order. Crafted by experts. Completed within 8 weeks.
-              </p>
-
+            {/* Link */}
+            <div className="text-left mb-6">
               <Link
                 href="/signature-rings"
                 className="inline-flex items-center text-stone-700 font-semibold text-lg hover:text-stone-800 transition-colors duration-300"
@@ -158,6 +157,16 @@ export default function WhatsMoreImportantSection() {
                   <path d="M0.224965 11.6535L0.680433 11.2741L6.41482 6.50947L0.695125 1.72429L0.239461 1.34394L0.692005 0.959639L1.09275 0.61923L1.41431 0.346123L1.73728 0.616962L8.32635 6.12764L8.78689 6.5119L8.32556 6.89522L1.71933 12.3845L1.39581 12.6547L0.675741 12.0387L0.224965 11.6535Z"/>
                 </svg>
               </Link>
+            </div>
+
+            {/* Description */}
+            <div className="text-left">
+              <p className="text-black text-sm lg:text-base leading-relaxed font-medium">
+                Prefer not to make a hundred tiny decisions? We&apos;ve combined our
+                most-loved ring designs with hand-selected, exquisite diamonds, so
+                you can entrust our team with curating your one-of-a-kind heirloom.
+                Made to order. Crafted by experts. Completed within 8 weeks.
+              </p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Purpose

Fix UI inconsistencies in the ring section to match the design specifications. The user identified several layout issues including duplicate headings, incorrect icon direction, misaligned text, and extra content that wasn't part of the original design.

## Code changes

- **Removed duplicate headings**: Eliminated redundant "Start Designing Your Ring", "Shop Ready to Ship Rings", and "Shop Curated Collection" headings that were appearing above the descriptions
- **Fixed text alignment**: Changed content containers from `text-center` to `text-left` for proper left alignment of links and descriptions
- **Corrected arrow direction**: Removed `transform rotate-90` class from SVG icons to display right-pointing arrows instead of downward-pointing ones
- **Removed extra content**: Deleted the additional information section containing the British craftsmanship text that wasn't in the original design
- **Code cleanup**: Fixed whitespace and formatting inconsistencies throughout the component

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/dc86bb58491c4556a25a103718165567/swoosh-landing)

👀 [Preview Link](https://dc86bb58491c4556a25a103718165567-swoosh-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>dc86bb58491c4556a25a103718165567</projectId>-->
<!--<branchName>swoosh-landing</branchName>-->